### PR TITLE
Fix UTF-8 compile error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
 		</developer>
 	</developers>
 
+	<properties>
+        	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jogamp.gluegen</groupId>


### PR DESCRIPTION
Fixes the error with the '§' char while compiling after git clone.

```
[ERROR] unclosed character literal
[ERROR] illegal character: \167
```